### PR TITLE
Add Parameterised Queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "covid19"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["biomunky"]
 edition = "2018"
 readme = "README.md"

--- a/examples/get_deaths.rs
+++ b/examples/get_deaths.rs
@@ -1,4 +1,4 @@
-use covid19;
+use chrono::NaiveDate;
 
 fn main() {
     let deaths = covid19::api::deaths();
@@ -7,4 +7,11 @@ fn main() {
         println!("{:?}", resp.data[0]);
         println!("{:?}", resp.metadata)
     }
+
+    let from = NaiveDate::from_ymd(2020, 4, 15);
+    let to = NaiveDate::from_ymd(2020, 4, 25);
+    let use_ground_truth = false;
+    let parameterised = covid19::api::parameterised_deaths(from, to, use_ground_truth);
+
+    println!("{:?}", parameterised)
 }

--- a/examples/get_deaths_by_region.rs
+++ b/examples/get_deaths_by_region.rs
@@ -1,10 +1,17 @@
-use covid19;
+use chrono::NaiveDate;
 
 fn main() {
-    let deaths_by_region = covid19::api::deaths_by_region();
+    let deaths = covid19::api::deaths_by_region();
 
-    if let Ok(resp) = deaths_by_region {
+    if let Ok(resp) = deaths {
         println!("{:?}", resp.data[0]);
         println!("{:?}", resp.metadata)
     }
+
+    let from = NaiveDate::from_ymd(2020, 4, 15);
+    let to = NaiveDate::from_ymd(2020, 4, 25);
+    let use_ground_truth = true;
+    let parameterised = covid19::api::parameterised_deaths_by_region(from, to, use_ground_truth);
+
+    println!("{:?}", parameterised)
 }

--- a/examples/get_deaths_by_trust.rs
+++ b/examples/get_deaths_by_trust.rs
@@ -1,10 +1,17 @@
-use covid19;
+use chrono::NaiveDate;
 
 fn main() {
-    let deaths_by_trust = covid19::api::deaths_by_trust();
+    let deaths = covid19::api::deaths_by_trust();
 
-    if let Ok(resp) = deaths_by_trust {
+    if let Ok(resp) = deaths {
         println!("{:?}", resp.data[0]);
         println!("{:?}", resp.metadata)
     }
+
+    let from = NaiveDate::from_ymd(2020, 4, 15);
+    let to = NaiveDate::from_ymd(2020, 4, 25);
+    let use_ground_truth = true;
+    let parameterised = covid19::api::parameterised_deaths_by_trust(from, to, use_ground_truth);
+
+    println!("{:?}", parameterised)
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,7 @@
 use super::data::{DeathsResponse, RegionsResponse, TrustsResponse};
 use anyhow::{anyhow, Result};
+use chrono::NaiveDate;
 use serde::de::DeserializeOwned;
-
-const BASE_URL: &str = "https://api.cv19api.com/api/v1/";
 
 fn fetch_resource(url: &str) -> Result<String> {
     static CLIENT_USER_AGENT: &str = concat!(
@@ -33,14 +32,94 @@ where
     Ok(serde_json::from_str::<T>(&r)?)
 }
 
+// TODO: unit test me
+fn url_for(
+    base_url: &str,
+    endpoint: &str,
+    use_ground_truth: Option<bool>,
+    from_date: NaiveDate,
+    to_date: NaiveDate,
+) -> String {
+    let (from_param, to_param) = if use_ground_truth.unwrap_or(true) {
+        ("from", "to")
+    } else {
+        ("recordedOnFrom", "recordedOnTo")
+    };
+    format!(
+        "{}{}?{}={}&{}={}",
+        base_url, endpoint, from_param, from_date, to_param, to_date
+    )
+}
+
+const BASE_URL: &str = "https://api.cv19api.com/api/v1/";
+const DEATHS_ENDPOINT: &str = "deaths";
+const REGIONS_ENDPOINT: &str = "deaths/regions";
+const TRUSTS_ENDPOINT: &str = "deaths/trusts";
+
 pub fn deaths() -> Result<DeathsResponse> {
-    fetch(&format!("{}{}", BASE_URL, "deaths"))
+    get_data(DEATHS_ENDPOINT, None, None, None)
+}
+
+pub fn parameterised_deaths(
+    from: NaiveDate,
+    to: NaiveDate,
+    use_ground_truth: bool,
+) -> Result<DeathsResponse> {
+    get_data(
+        DEATHS_ENDPOINT,
+        Some(from),
+        Some(to),
+        Some(use_ground_truth),
+    )
 }
 
 pub fn deaths_by_region() -> Result<RegionsResponse> {
-    fetch(&format!("{}{}", BASE_URL, "deaths/regions"))
+    get_data(REGIONS_ENDPOINT, None, None, None)
+}
+
+pub fn parameterised_deaths_by_region(
+    from: NaiveDate,
+    to: NaiveDate,
+    use_ground_truth: bool,
+) -> Result<RegionsResponse> {
+    get_data(
+        REGIONS_ENDPOINT,
+        Some(from),
+        Some(to),
+        Some(use_ground_truth),
+    )
 }
 
 pub fn deaths_by_trust() -> Result<TrustsResponse> {
-    fetch(&format!("{}{}", BASE_URL, "deaths/trusts"))
+    get_data(TRUSTS_ENDPOINT, None, None, None)
+}
+
+pub fn parameterised_deaths_by_trust(
+    from: NaiveDate,
+    to: NaiveDate,
+    use_ground_truth: bool,
+) -> Result<TrustsResponse> {
+    get_data(
+        TRUSTS_ENDPOINT,
+        Some(from),
+        Some(to),
+        Some(use_ground_truth),
+    )
+}
+
+fn get_data<T>(
+    endpoint: &str,
+    from: Option<NaiveDate>,
+    to: Option<NaiveDate>,
+    use_ground_truth: Option<bool>,
+) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    
+    let url = match (from, to) {
+        (Some(from_date), Some(to_date)) => url_for(BASE_URL, endpoint, use_ground_truth, from_date, to_date),
+        _ => format!("{}{}", BASE_URL, endpoint),
+    };
+    fetch(&url)
 }


### PR DESCRIPTION
The api allows two start and end points to be set for all endpoints:

* from / to
* recordedOnFrom / recordedOnTo

These are now exposed as two sets of functions, one parameterised the other not.
In order to switch between from/recordedOnFrom the use has to set a bool called
use_ground_truth.

Bump version number